### PR TITLE
Made the Pinned Reply move to the top (refresh does not preserve)

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -108,7 +108,7 @@ define('forum/topic/postTools', [
 		});
 
 		postContainer.on('click', '[component="post/pin"]', function () {
-			onPinClicked($(this), tid);
+			onPinClicked($(this));
 		});
 
 		postContainer.on('click', '[component="post/reply"]', function () {
@@ -331,30 +331,12 @@ define('forum/topic/postTools', [
 		});
 	}
 
-	async function onPinClicked(button, tid) {
-		const selectedNode = await getSelectedNode();
-
-		showStaleWarning(async function () {
-			const username = await getUserSlug(button);
-			const toPid = getData(button, 'data-pid');
-
-			function quote(text) {
-				hooks.fire('action:composer.addQuote', {
-					tid: tid,
-					pid: toPid,
-					username: username,
-					title: ajaxify.data.titleRaw,
-					text: text,
-				});
-			}
-
-			if (selectedNode.text && toPid && toPid === selectedNode.pid) {
-				return quote(selectedNode.text);
-			}
-
-			const { content } = await api.get(`/posts/${toPid}/raw`);
-			quote(content);
-		});
+	async function onPinClicked(button) {
+		const pid = getData(button, 'data-pid');
+		const container = document.querySelector('[component="topic"]');
+		const currentPost = container.querySelector(`[data-pid='${pid}']`);		
+		const firstPost = container.firstChild;
+		container.insertBefore(currentPost, firstPost);
 	}
 
 	async function getSelectedNode() {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -334,7 +334,7 @@ define('forum/topic/postTools', [
 	async function onPinClicked(button) {
 		const pid = getData(button, 'data-pid');
 		const container = document.querySelector('[component="topic"]');
-		const currentPost = container.querySelector(`[data-pid='${pid}']`);		
+		const currentPost = container.querySelector(`[data-pid='${pid}']`);
 		const firstPost = container.firstChild;
 		container.insertBefore(currentPost, firstPost);
 	}


### PR DESCRIPTION
- I added a backend logic to make Pinned Reply move to the top.
- However, I have not made any API calls, therefore, when refreshing the page, it will NOT stay as it is supposed to. This involves much more work so will be done later. The following tasks need to be done to make the changes preserved after refreshing page:
       + Add a 'pinned' field to the database schema for posts: I have not figured how to do this but I spent hours on looking for  example with the Bookmark Post feature.
       + Create API endpoints to handle pinning and unpinning: this looks like it's involving like 15+ files so it's not doable for this sprint.
       + Adjust frontend to send requests to these endpoints when posts are pinned/unpinned
- I tested the changes locally.