### PR TITLE
Admin Setting: Add toggle to enable anonymous posting

### DIFF
--- a/public/language/en-GB/admin/settings/post.json
+++ b/public/language/en-GB/admin/settings/post.json
@@ -60,5 +60,6 @@
 	"backlinks.help": "If a post references another topic, a link back to the post will be inserted into the referenced topic at that point in time.",
 	"ip-tracking": "IP Tracking",
 	"ip-tracking.each-post": "Track IP Address for each post",
-	"enable-post-history": "Enable Post History"
+	"enable-post-history": "Enable Post History",
+	"enable-anonymous-posting": "Enable Anonymous Posting"
 }

--- a/public/language/en-US/admin/settings/post.json
+++ b/public/language/en-US/admin/settings/post.json
@@ -60,5 +60,6 @@
 	"backlinks.help": "If a post references another topic, a link back to the post will be inserted into the referenced topic at that point in time.",
 	"ip-tracking": "IP Tracking",
 	"ip-tracking.each-post": "Track IP Address for each post",
-	"enable-post-history": "Enable Post History"
+	"enable-post-history": "Enable Post History",
+	"enable-anonymous-posting": "Enable Anonymous Posting"
 }

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -27,6 +27,11 @@
 				</div>
 
 				<div class="form-check form-switch mb-3">
+					<input class="form-check-input" type="checkbox" id="enableAnonymousPosting" data-field="enableAnonymousPosting" checked />
+					<label class="form-check-label" for="enableAnonymousPosting">[[admin/settings/post:enable-anonymous-posting]]</label>
+				</div>
+
+				<div class="form-check form-switch mb-3">
 					<input class="form-check-input" type="checkbox" id="enablePostHistory" data-field="enablePostHistory" checked />
 					<label class="form-check-label" for="enablePostHistory">[[admin/settings/post:enable-post-history]]</label>
 				</div>


### PR DESCRIPTION
This change add a toggle button in the admin post setting to allow admin to enable anonymous posting for the server but just frontend.  

Currently, I am still working on the backend to allow the enabling of this function, where I got a global variable created and linked with the toggle, just stuck on npm run test with the following error:

AssertionError [ERR_ASSERTION]: "enableAnonymousPosting" is a required property (path: GET /api/admin/config, context: root)
      + expected - actual

      -false
      +true
      
After the above issue is fixed, the Admin setting control of enabling anonymous posting should be fully done.

<img width="1344" alt="Screenshot 2025-02-08 at 7 12 51 PM" src="https://github.com/user-attachments/assets/f9dead82-8d34-4f04-8dcf-53dc94e099a8" />
