### PR TITLE
Modify Status Options Based on Anonymous Posting Settings

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -15,6 +15,7 @@
     "newbiePostEditDuration": 3600,
     "postDeleteDuration": 0,
     "enablePostHistory": 1,
+	"enableAnonymousPosting": 1,
     "topicBacklinks": 1,
     "postCacheSize": 20971520,
     "disableChat": 0,

--- a/nodebb-theme-harmony/templates/partials/sidebar/user-menu.tpl
+++ b/nodebb-theme-harmony/templates/partials/sidebar/user-menu.tpl
@@ -39,6 +39,7 @@
 			<i class="fa-solid fa-check text-secondary flex-shrink-0"></i>
 		</a>
 	</li>
+	{{{ if enableAnonymousPosting }}}
 	<li>
 		<a href="#" class="dropdown-item rounded-1 user-status d-flex align-items-center gap-2 {{{ if user.anonymous }}}selected{{{ end }}}" data-status="anonymous" role="menuitem">
 			<span component="user/status" class="flex-shrink-0 border border-white border-2 rounded-circle status anonymous"></span>
@@ -46,6 +47,7 @@
 			<i class="fa-solid fa-check text-secondary flex-shrink-0"></i>
 		</a>
 	</li>
+	{{{ end }}}
 	<li role="presentation" class="dropdown-divider"></li>
 	<li>
 		<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="{relative_path}/user/{user.userslug}/bookmarks" role="menuitem">

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -351,6 +351,7 @@ module.exports = function (middleware) {
 		hookReturn.templateData.useCustomJS = meta.config.useCustomJS;
 		hookReturn.templateData.customJS = hookReturn.templateData.useCustomJS ? meta.config.customJS : '';
 		hookReturn.templateData.isSpider = req.uid === -1;
+		hookReturn.templateData.enableAnonymousPosting = meta.config.enableAnonymousPosting;
 
 		return await req.app.renderAsync('footer', hookReturn.templateData);
 	}

--- a/src/socket.io/user/status.js
+++ b/src/socket.io/user/status.js
@@ -2,6 +2,7 @@
 
 const user = require('../../user');
 const websockets = require('../index');
+const meta = require('../../meta');
 
 module.exports = function (SocketUser) {
 	SocketUser.checkStatus = async function (socket, uid) {
@@ -17,7 +18,10 @@ module.exports = function (SocketUser) {
 			throw new Error('[[error:invalid-uid]]');
 		}
 
-		const allowedStatus = ['online', 'offline', 'dnd', 'away', 'anonymous'];
+		let allowedStatus = ['online', 'offline', 'dnd', 'away', 'anonymous'];
+		if (!meta.config.enableAnonymousPosting) {
+			allowedStatus = ['online', 'offline', 'dnd', 'away'];
+		}
 		if (!allowedStatus.includes(status)) {
 			throw new Error('[[error:invalid-user-status]]');
 		}


### PR DESCRIPTION
This change creates global variable for anonymous posting.  Using the global variable, the frontend render the status options based on the current anonymous posting setting.  So if the anonymous posting setting is on, there will be an option to switch to anonymous posting mode, else the option will not exist for users.

Link #29 