### PR TITLE
Add StandardJS static analysis tool

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -14,7 +14,8 @@
         "lint": "eslint --cache ./nodebb .",
         "test": "nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+		"standard": "standard"
     },
     "nyc": {
         "exclude": [
@@ -170,7 +171,8 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
-        "smtp-server": "3.13.4"
+        "smtp-server": "3.13.4",
+		"standard": "*"
     },
     "optionalDependencies": {
         "sass-embedded": "1.77.1"


### PR DESCRIPTION
This pull request adds the StandardJS static analysis tool.  StandardJS is a style guide for javascript that requires no configuration and has the option to automatically format code.  The package is added to install/package.json.  To use StandardJS locally, run `npm install` to install StandardJS and run `npm run standard` to see results from StandardJS.

StandardJS Documentation: https://standardjs.com/

The following screenshot is the last lines of the result from running `npm run standard`.  There were too many suggestions from StandardJS, so I just recorded the last ones.
<img width="739" alt="Screenshot 2025-03-11 at 9 56 27 AM" src="https://github.com/user-attachments/assets/382665c3-9426-4a26-8f9e-dbd5995ecd1e" />
