### PR TITLE
Failed Attempts at other Dynamic Analysis Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ test.sh
 
 .docker/**
 !**/.gitkeep
+# stryker temp files
+.stryker-tmp

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,3 +1,6 @@
+spec: 
+  - ./test/*.js 
+  - ./test/**/*.js
 reporter: dot
 timeout: 25000
 exit: true

--- a/iroh.js
+++ b/iroh.js
@@ -1,0 +1,51 @@
+console.log('a');
+const Iroh = require("../iroh");
+const fs = require('fs');
+console.log('what');
+// Turning test script into string for Iroh stage
+const path = '/workspaces/nodebb-s25-eagles/test/posts.js';
+const code = "" + fs.readFileSync(path, 'utf8');
+
+// initializing stage
+console.log("Iroh running...")
+const stage = new Iroh.Stage(code);
+stage.addListener (Iroh.call)
+.on ("before", (e) => {
+    let external = e.external ? "#external" : "";
+    console.log(" ".repeat(e.indent) + "call", e.name, external, "(", e.arguments, ")");
+})
+.on("after", (e) => {
+    let external = e.external ? "#external" : "";
+    console.log(" ".repeat(e.indent) + "call", e.name, "end", external, "->", [e.return]);
+  });
+// creating function listeners
+  stage.addListener(Iroh.FUNCTION)
+.on("enter", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, sloppy, "(", e.arguments, ")");
+  }
+})
+.on("leave", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, "end", sloppy, "->", [void 0]);
+  }
+})
+.on("return", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, "end", sloppy, "->", [e.return]);
+  }
+});
+
+// begining and end of test
+stage.addListener(Iroh.PROGRAM)
+.on("enter", (e) => {
+  console.log(" ".repeat(e.indent) + "Program");
+})
+.on("leave", (e) => {
+  console.log(" ".repeat(e.indent) + "Program end", "->", e.return);
+});
+
+eval (stage.script);

--- a/iroh.js
+++ b/iroh.js
@@ -1,7 +1,6 @@
 console.log('a');
-const Iroh = require("../iroh");
+const Iroh = require("iroh");
 const fs = require('fs');
-console.log('what');
 // Turning test script into string for Iroh stage
 const path = '/workspaces/nodebb-s25-eagles/test/posts.js';
 const code = "" + fs.readFileSync(path, 'utf8');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -111,7 +111,6 @@ prestart.versionCheck();
 
 if (!configExists && process.argv[2] !== 'setup') {
 	require('./setup').webInstall();
-	return;
 }
 
 if (configExists) {

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "npm",
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
+  "testRunner": "mocha",
+  "coverageAnalysis": "perTest"
+}

--- a/test/stryker.config.json
+++ b/test/stryker.config.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "npm",
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
+  "testRunner": "mocha",
+  "testRunner_comment": "Take a look at https://stryker-mutator.io/docs/stryker-js/mocha-runner for information about the mocha plugin.",
+  "coverageAnalysis": "perTest",
+  "mochaOptions": {
+    "spec": [ "./*.js", "**/*.js"],
+    "config": "",
+    "package": "",
+    "opts": "",
+    "ui": "bdd",
+    "require": [ "babel-register" ],
+    "async-only": false,
+    "grep": ".*",
+    "--no-config": true,
+    "--no-package": true,
+    "--no-opts": true
+  }
+}


### PR DESCRIPTION
**Dynamic Analysis Tools Explored**
- [**Iroh**](https://maierfelix.github.io/Iroh/)
- [**Stryker**](https://stryker-mutator.io/docs/stryker-js/introduction/) 
- [**Crawljax**]()
- [**Clinic.js**](https://clinicjs.org/documentation/doctor/01-setup/) 
- [**Redis Memory Analyzer (RMA)**](https://github.com/gamenet/redis-memory-analyzer/blob/master/README.rst) 
- [**Dlint**](https://github.com/Berkeley-Correctness-Group/DLint/blob/master/README.md)
- [**Jit**](http//:/jit.io/)
- [**Zap**](https://www.zaproxy.org/download/)

**Note**
Each commit will detail approximately up to where I attempted with each dynamic analysis tool. The commit will be named after the tool and the details of the commit will elaborate on what was learned and what went wrong. Unfortunately, I did not realize at the time that it would be wise to save the changes as they were made and deleted all previous work whenever I started over from square 1. The timeline in the commits will not reflect how much time was spent on each tool, and the changes will be rough recreations.

**Rough Outline**
-<b>Iroh</b> : I just had a hard time trying to fit Iroh into the implementation. It seemed to have trouble reading async functions, before(), and other modules utilized in the test files. Eventually, I tried creating my own dedicated Iroh test script to run, but it would run into more type conflicts like crashing out over zscores and hbrf (or something like that). So I gave up.<br>-<b>Stryker</b>: tldr; couldn't figure out how to configurate test specs so that it would only run on the test files. <br>If it ran on the entire repo, it would consistently return EISDIR errors because it wasn't copying deep enough, it was disregarding certain filetypes, or it couldn't handle empty directories. I tried to configure the mochaarc.yaml file, but it didn't seem to pick up on the changes made because it would read all the files despite attempting to filter the tests to specific directories.<br>I then attempted running Stryker with the config file within the test file. That initially seemed to work except it would run into an error regarding a `return` statement in an `if` statement not within a function. Ultimately, since it was not returning anything as the return statement was `return;`, I disregarded it for the sake of progressing forward. However, it would then return an error regarding `mochaOptions` despite following configuration documentation. </br>-<b>Clinic JS</b>: Only works with `restify` servers. I tried messing with the running procedure of the code, but ultimately the report would be unable to generate properly as the listeners failed to report the required metrics.<br>-<b>RMA</b>: Had difficulty installing pip in the dev container. Despite all required dependencies being installed, I could not get pip to install so I ultimately never even got to try running the tool in the environment.<br>-<b>Crawljax</b>: Downloaded java and required java-related programs like JDK to the dev container. Despite that, I had difficulty compiling the source code to actually run the tool. <br>-<b>Dlint</b>: It was not compatible the linux. </3<br>-<b>Zap</b>: Sorta successful. It ran some tests, but ultimately the problem was with getting the module in the container. I had difficulty mounting an existing container onto a new container with an image of Docker images of Zap. Downloading via `sudo apt get` was failing for an unknown reason despite following installation instructions to the specfications of the virtual container. I tried following installation instructions for Debian 12 as that was what was specified when calling `lsb_release -a` in the workspace terminal. The modules did not exist for the dev containers for some reason. Ultimately, I downloaded Zap onto my local machine and booted up a local redis server and nodebb. I then entered `http://localhost:4567` as the URL to test and had it run a comprehensive performance test which yielded the most useful insight regarding performance.<br>-<b>Jit</b>: The last analysis tool I worked with gave insight into security vulnerabilities. However, most of the useful dynamic tests were stuck behind input field restrictions. The api url is `<public ip address>:<port>/api` but any input with a slash or period was considered an invalid API URL. Failure to fill out the field would also block the form from being submitted. Since Zap worked when run locally, it feels like figuring out how to get around the field restrictions with command line or script changes is a valid path to go down. 