### PR TITLE
Add Zap as Part of Push Workflow 

### DIFF
--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -1,6 +1,9 @@
 name: OWASP ZAP Baseline Scan
 
 on:
+  push:
+    branches:
+      - newMain
   workflow_run:
     workflows: ["VM Deploy NodeBB"]
     types:


### PR DESCRIPTION
This PR adds Zap as a part of the push workflow to main.  Previously, Zap runs after VM deployment is successful, but you can see it under the commit log.  To see the action of Zap, you will have to navigate to Actions to see whether it successes.  Thus, this PR allows Zap to be seen in the commit logs.