### PR TITLE
Revert Zap.yaml to only on_workflow

### DIFF
--- a/.github/workflows/VM-deploy.yml
+++ b/.github/workflows/VM-deploy.yml
@@ -1,4 +1,4 @@
-name: VM-Deploy-NodeBB
+name: VM Deploy NodeBB
 
 on:
   push:

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -3,14 +3,14 @@ name: OWASP ZAP Baseline Scan
 on:
   push:
     workflow_run:
-    workflows: ["VM-Deploy-NodeBB"]
-    types: [completed]
+      workflows: ["VM-Deploy-NodeBB"]
+      types: [completed]
     branches:
       - newMain
   pull_request:
     workflow_run:
-    workflows: ["Lint and test"]
-    types: [completed]
+      workflows: ["Lint and test"]
+      types: [completed]
     branches:
       - main
       - newMain

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -31,16 +31,15 @@ jobs:
     env:
       TEST_ENV: "production"
       DEEPSEEK_API_ACCESS_TOKEN: ${{ secrets.DEEPSEEK_API_ACCESS_TOKEN }}
-      
+
     steps:
+      - uses: actions/checkout@v4
+      
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           echo "$GITHUB_CONTEXT"
-
-    steps:
-      - uses: actions/checkout@v4
 
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.14.0

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -24,8 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
+      - name: OWASP ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: ${{ secrets.ZAP_TARGET }}

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -2,11 +2,19 @@ name: OWASP ZAP Baseline Scan
 
 on:
   push:
-    branches:
-      - newMain
-  workflow_run:
+    workflow_run:
     workflows: ["VM-Deploy-NodeBB"]
     types: [completed]
+    branches:
+      - newMain
+  pull_request:
+    workflow_run:
+    workflows: ["Lint and test"]
+    types: [completed]
+    branches:
+      - main
+      - newMain
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -1,20 +1,10 @@
 name: OWASP ZAP Baseline Scan
 
 on:
-  push:
-    workflow_run:
-      workflows: ["VM-Deploy-NodeBB"]
-      types: [completed]
-    branches:
-      - newMain
-  pull_request:
-    workflow_run:
-      workflows: ["Lint and test"]
-      types: [completed]
-    branches:
-      - main
-      - newMain
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["VM Deploy NodeBB"]
+    types:
+      - completed
 
 defaults:
   run:
@@ -26,7 +16,6 @@ permissions:
 
 jobs:
   test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Ensures it runs only if the VM deploy is successful
     runs-on: ubuntu-latest
     env:
       TEST_ENV: "production"

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -31,6 +31,13 @@ jobs:
     env:
       TEST_ENV: "production"
       DEEPSEEK_API_ACCESS_TOKEN: ${{ secrets.DEEPSEEK_API_ACCESS_TOKEN }}
+      
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   test:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Ensures it runs only if the VM deploy is successful
     runs-on: ubuntu-latest
     env:
       TEST_ENV: "production"

--- a/.github/workflows/zap.yaml
+++ b/.github/workflows/zap.yaml
@@ -34,14 +34,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           echo "$GITHUB_CONTEXT"
-
-      - name: OWASP ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.14.0
-        with:
-          target: ${{ secrets.ZAP_TARGET }}


### PR DESCRIPTION
There was a misunderstanding that Zap need to show up in commit logs using on_push, but that only causes the tool to get skipped.  It was confirmed by TA that on_workflow is allow and sufficient.