### PR TITLE
LLM Service (HardCoded Version)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,19 @@
 version: "3.8"
 
 services:
+  translator:
+    build:
+      context: ../translator-service
+    command: flask run --host=0.0.0.0
+    ports:
+      - "5000:5000"
+    environment:
+      FLASK_APP: app.py 
+      FLASK_ENV: development 
+    volumes:
+      - ../translator-service:/app
+    working_dir: /app
+    restart: unless-stopped
   nodebb:
     user: "0"
     build: .

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -66,6 +66,15 @@
 
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
+
+		{{{if !posts.isEnglish }}}
+		        <div class="sensitive-content-message">
+		        <a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
+		        </div>
+		        <div class="translated-content" style="display:none;">
+		        {posts.translatedContent}
+		        </div>
+	    {{{end}}}
 		</div>
 	</div>
 </div>

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -9,6 +9,8 @@ PostObject:
       description: A topic identifier
     content:
       type: string
+    isEnglish:
+      type: boolean
     uid:
       type: number
       description: A user identifier
@@ -39,7 +41,8 @@ PostObject:
           description: This is either username or fullname depending on forum and user settings
         userslug:
           type: string
-          description: An URL-safe variant of the username (i.e. lower-cased, spaces
+          description:
+            An URL-safe variant of the username (i.e. lower-cased, spaces
             removed, etc.)
         picture:
           type: string
@@ -48,12 +51,14 @@ PostObject:
           type: string
         icon:text:
           type: string
-          description: A single-letter representation of a username. This is used in the
+          description:
+            A single-letter representation of a username. This is used in the
             auto-generated icon given to users without
             an avatar
         icon:bgColor:
           type: string
-          description: A six-character hexadecimal colour code assigned to the user. This
+          description:
+            A six-character hexadecimal colour code assigned to the user. This
             value is used in conjunction with
             `icon:text` for the user's auto-generated
             icon
@@ -87,7 +92,8 @@ PostObject:
           type: number
         mainPid:
           type: number
-          description: The post id of the first post in this topic (also called the
+          description:
+            The post id of the first post in this topic (also called the
             "original post")
         teaserPid:
           type: number
@@ -125,7 +131,8 @@ PostObject:
           type: string
         parentCid:
           type: number
-          description: The category identifier for the category that is the immediate
+          description:
+            The category identifier for the category that is the immediate
             ancestor of the current category
         bgColor:
           type: string

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -96,19 +96,22 @@ get:
                                                   description: A friendly name for a given user account
                                                 userslug:
                                                   type: string
-                                                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                                  description:
+                                                    An URL-safe variant of the username (i.e. lower-cased, spaces
                                                     removed, etc.)
                                                 picture:
                                                   nullable: true
                                                   type: string
                                                 icon:text:
                                                   type: string
-                                                  description: A single-letter representation of a username. This is used in the
+                                                  description:
+                                                    A single-letter representation of a username. This is used in the
                                                     auto-generated icon given to
                                                     users without an avatar
                                                 icon:bgColor:
                                                   type: string
-                                                  description: A six-character hexadecimal colour code assigned to the user. This
+                                                  description:
+                                                    A six-character hexadecimal colour code assigned to the user. This
                                                     value is used in conjunction
                                                     with `icon:text` for the user's
                                                     auto-generated icon
@@ -142,6 +145,8 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
                                   anonymous:
                                     type: number
                                   timestampISO:
@@ -161,19 +166,22 @@ get:
                                         description: This is either username or fullname depending on forum and user settings
                                       userslug:
                                         type: string
-                                        description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                        description:
+                                          An URL-safe variant of the username (i.e. lower-cased, spaces
                                           removed, etc.)
                                       picture:
                                         nullable: true
                                         type: string
                                       icon:text:
                                         type: string
-                                        description: A single-letter representation of a username. This is used in the
+                                        description:
+                                          A single-letter representation of a username. This is used in the
                                           auto-generated icon given to users
                                           without an avatar
                                       icon:bgColor:
                                         type: string
-                                        description: A six-character hexadecimal colour code assigned to the user. This
+                                        description:
+                                          A six-character hexadecimal colour code assigned to the user. This
                                           value is used in conjunction with
                                           `icon:text` for the user's
                                           auto-generated icon
@@ -219,29 +227,29 @@ get:
                                 user:
                                   type: object
                                   properties:
-                                      uid:
-                                        type: number
-                                        example: 1
-                                      username:
-                                        type: string
-                                        example: Dragon Fruit
-                                      userslug:
-                                        type: string
-                                        example: dragon-fruit
-                                      picture:
-                                        type: string
-                                        example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
-                                        nullable: true
-                                      displayname:
-                                        type: string
-                                        description: This is either username or fullname depending on forum and user settings
-                                        example: Dragon Fruit
-                                      'icon:text':
-                                        type: string
-                                        example: D
-                                      'icon:bgColor':
-                                        type: string
-                                        example: '#9c27b0'
+                                    uid:
+                                      type: number
+                                      example: 1
+                                    username:
+                                      type: string
+                                      example: Dragon Fruit
+                                    userslug:
+                                      type: string
+                                      example: dragon-fruit
+                                    picture:
+                                      type: string
+                                      example: "https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80"
+                                      nullable: true
+                                    displayname:
+                                      type: string
+                                      description: This is either username or fullname depending on forum and user settings
+                                      example: Dragon Fruit
+                                    "icon:text":
+                                      type: string
+                                      example: D
+                                    "icon:bgColor":
+                                      type: string
+                                      example: "#9c27b0"
                             imageClass:
                               type: string
               - $ref: ../components/schemas/Pagination.yaml#/Pagination

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -94,19 +94,22 @@ get:
                                                   description: This is either username or fullname depending on forum and user settings
                                                 userslug:
                                                   type: string
-                                                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                                  description:
+                                                    An URL-safe variant of the username (i.e. lower-cased, spaces
                                                     removed, etc.)
                                                 picture:
                                                   nullable: true
                                                   type: string
                                                 icon:text:
                                                   type: string
-                                                  description: A single-letter representation of a username. This is used in the
+                                                  description:
+                                                    A single-letter representation of a username. This is used in the
                                                     auto-generated icon given to
                                                     users without an avatar
                                                 icon:bgColor:
                                                   type: string
-                                                  description: A six-character hexadecimal colour code assigned to the user. This
+                                                  description:
+                                                    A six-character hexadecimal colour code assigned to the user. This
                                                     value is used in conjunction
                                                     with `icon:text` for the user's
                                                     auto-generated icon
@@ -118,7 +121,8 @@ get:
                                               description: A category identifier
                                             parentCid:
                                               type: number
-                                              description: The category identifier for the category that is the immediate
+                                              description:
+                                                The category identifier for the category that is the immediate
                                                 ancestor of the current category
                                             topic:
                                               type: object
@@ -144,6 +148,8 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
                                   anonymous:
                                     type: number
                                   timestampISO:
@@ -163,19 +169,22 @@ get:
                                         description: This is either username or fullname depending on forum and user settings
                                       userslug:
                                         type: string
-                                        description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                        description:
+                                          An URL-safe variant of the username (i.e. lower-cased, spaces
                                           removed, etc.)
                                       picture:
                                         nullable: true
                                         type: string
                                       icon:text:
                                         type: string
-                                        description: A single-letter representation of a username. This is used in the
+                                        description:
+                                          A single-letter representation of a username. This is used in the
                                           auto-generated icon given to users
                                           without an avatar
                                       icon:bgColor:
                                         type: string
-                                        description: A six-character hexadecimal colour code assigned to the user. This
+                                        description:
+                                          A six-character hexadecimal colour code assigned to the user. This
                                           value is used in conjunction with
                                           `icon:text` for the user's
                                           auto-generated icon
@@ -221,29 +230,29 @@ get:
                                 user:
                                   type: object
                                   properties:
-                                      uid:
-                                        type: number
-                                        example: 1
-                                      username:
-                                        type: string
-                                        example: Dragon Fruit
-                                      userslug:
-                                        type: string
-                                        example: dragon-fruit
-                                      picture:
-                                        type: string
-                                        example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
-                                        nullable: true
-                                      displayname:
-                                        type: string
-                                        description: This is either username or fullname depending on forum and user settings
-                                        example: Dragon Fruit
-                                      'icon:text':
-                                        type: string
-                                        example: D
-                                      'icon:bgColor':
-                                        type: string
-                                        example: '#9c27b0'
+                                    uid:
+                                      type: number
+                                      example: 1
+                                    username:
+                                      type: string
+                                      example: Dragon Fruit
+                                    userslug:
+                                      type: string
+                                      example: dragon-fruit
+                                    picture:
+                                      type: string
+                                      example: "https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80"
+                                      nullable: true
+                                    displayname:
+                                      type: string
+                                      description: This is either username or fullname depending on forum and user settings
+                                      example: Dragon Fruit
+                                    "icon:text":
+                                      type: string
+                                      example: D
+                                    "icon:bgColor":
+                                      type: string
+                                      example: "#9c27b0"
                             imageClass:
                               type: string
               - $ref: ../components/schemas/Pagination.yaml#/Pagination

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -63,7 +63,11 @@ get:
                           description: A topic identifier
                         content:
                           type: string
-                        anonymous: 
+                        translatedContent:
+                          type: string
+                        isEnglish:
+                          type: boolean
+                        anonymous:
                           type: number
                         timestamp:
                           type: number
@@ -102,7 +106,8 @@ get:
                               description: This is either username or fullname depending on forum and user settings
                             userslug:
                               type: string
-                              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                              description:
+                                An URL-safe variant of the username (i.e. lower-cased, spaces
                                 removed, etc.)
                             reputation:
                               type: number
@@ -139,12 +144,14 @@ get:
                               nullable: true
                             icon:text:
                               type: string
-                              description: A single-letter representation of a username. This is used in the
+                              description:
+                                A single-letter representation of a username. This is used in the
                                 auto-generated icon given to users without
                                 an avatar
                             icon:bgColor:
                               type: string
-                              description: A six-character hexadecimal colour code assigned to the user. This
+                              description:
+                                A six-character hexadecimal colour code assigned to the user. This
                                 value is used in conjunction with
                                 `icon:text` for the user's auto-generated
                                 icon
@@ -203,7 +210,8 @@ get:
                                     description: A friendly name for a given user account
                                   userslug:
                                     type: string
-                                    description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                    description:
+                                      An URL-safe variant of the username (i.e. lower-cased, spaces
                                       removed, etc.)
                                   picture:
                                     type: string
@@ -212,12 +220,14 @@ get:
                                     description: A user identifier
                                   icon:text:
                                     type: string
-                                    description: A single-letter representation of a username. This is used in the
+                                    description:
+                                      A single-letter representation of a username. This is used in the
                                       auto-generated icon given to users without
                                       an avatar
                                   icon:bgColor:
                                     type: string
-                                    description: A six-character hexadecimal colour code assigned to the user. This
+                                    description:
+                                      A six-character hexadecimal colour code assigned to the user. This
                                       value is used in conjunction with
                                       `icon:text` for the user's auto-generated
                                       icon

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -12,7 +12,7 @@ get:
       description: a valid post id
       example: 1
   responses:
-    '200':
+    "200":
       description: Post successfully retrieved
       content:
         application/json:
@@ -34,6 +34,10 @@ get:
                     description: A topic identifier
                   content:
                     type: string
+                  translatedContent:
+                    type: string
+                  isEnglish:
+                    type: boolean
                   anonymous:
                     type: number
                   timestamp:
@@ -97,7 +101,7 @@ put:
           required:
             - content
   responses:
-    '200':
+    "200":
       description: Post successfully edited
       content:
         application/json:
@@ -129,7 +133,7 @@ delete:
       description: a valid post id
       example: 1
   responses:
-    '200':
+    "200":
       description: Post successfully purged
       content:
         application/json:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -71,11 +71,26 @@ define('forum/topic', [
 		handleThumbs();
 
 		$(window).on('scroll', utils.debounce(updateTopicTitle, 250));
+		configurePostToggle();
 
 		handleTopicSearch();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
+
+	function configurePostToggle() {
+		$('.topic').on('click', '.view-translated-btn', function () {
+			// Toggle the visibility of the next .translated-content div
+			$(this).closest('.sensitive-content-message').next('.translated-content').toggle();
+			// Optionally, change the button text based on visibility
+			var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+			if (isVisible) {
+				$(this).text('Hide the translated message.');
+			} else {
+				$(this).text('Click here to view the translated message.');
+			}
+		});
+	}
 
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -10,6 +10,7 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
+const translate = require('../translate');
 
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
@@ -19,6 +20,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const [isEnglish, translatedContent] = await translate.translate(data);
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -36,6 +38,8 @@ module.exports = function (Posts) {
 			content: content,
 			timestamp: timestamp,
 			anonymous: data.anonymous,
+			translatedContent: translatedContent,
+			isEnglish: isEnglish,
 		};
 
 		if (data.toPid) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -67,5 +67,8 @@ function modifyPost(post, fields) {
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
+
+		// Mark post as "English" if decided by translator service or if it has no info
+		post.isEnglish = post.isEnglish === 'true' || post.isEnglish === undefined;
 	}
 }

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const request = require('request');
-
-console.log(request);
-
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
-	const TRANSLATOR_API = 'http://translator:5000/';
+	const TRANSLATOR_API = 'http:17313-team01.s3d.cmu.edu:5000';
 	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
-	console.log(data);
+	if (!data || data.is_english === undefined || data.translated_content === undefined) {
+		return [true, postData.content];
+	}
 	return [data.is_english, data.translated_content];
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const request = require('request');
+
+const translatorApi = module.exports;
+
+translatorApi.translate = async function (postData) {
+	const TRANSLATOR_API = 'http://translator:5000/';
+	const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+	const data = await response.json();
+	console.log(data);
+	return [data['is_english'], data['translated_content']];
+};

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,12 +2,14 @@
 
 const request = require('request');
 
+console.log(request);
+
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
 	const TRANSLATOR_API = 'http://translator:5000/';
-	const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
 	console.log(data);
-	return [data['is_english'], data['translated_content']];
+	return [data.is_english, data.translated_content];
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -4,10 +4,14 @@ const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
 	const TRANSLATOR_API = 'http:17313-team01.s3d.cmu.edu:5000';
-	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
-	const data = await response.json();
-	if (!data || data.is_english === undefined || data.translated_content === undefined) {
+	try {
+		const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
+		const data = await response.json();
+		if (!data || data.is_english === undefined || data.translated_content === undefined) {
+			return [true, postData.content];
+		}
+		return [data.is_english, data.translated_content];
+	} catch (someError) {
 		return [true, postData.content];
 	}
-	return [data.is_english, data.translated_content];
 };


### PR DESCRIPTION
This pull request adds the template code provided by the repo (link provided below).  The template code (with placement of the translator service link to http://127.0.0.1:5000) successfully detect and translate non-English code.  Given the translator service deployed correctly, this pull request should correctly integrate the hard coded translator service into the deployed website.

Note in the future, if anyone want to test this service locally, either use Docker to host the server or follow the instruction in that repo to run the service on local host and change the translate API link to http://127.0.0.1:5000.

Template Repo: https://github.com/CMU-313/translator-service

Screenshot that shows a local version that successfully translated a hard coded response:
![image (2)](https://github.com/user-attachments/assets/8048b9c3-4a5c-45df-8493-d180c0207573)
