### PR TITLE
Revert "Add npm link harmony"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN groupadd --gid ${GID} ${USER} \
 
 USER ${USER}
 
-RUN npm link nodebb-theme-harmony
 RUN npm install --omit=dev
     # TODO: generate lockfiles for each package manager
     ## pnpm import \


### PR DESCRIPTION
Reverts CMU-313/nodebb-s25-eagles#66
This reversion is needed, so we can try run the commands in technical support to check if we can fix frontend.
Link to commands in technical support: https://cmu-313-s25.slack.com/archives/C087810EGR0/p1744079868575379