### PR TITLE
Add an OpenAI API Key to translator service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       FLASK_APP: app.py 
       FLASK_ENV: development 
+      OPENAI_API_KEY: ${{ secrets.OPENAPI_KEY }}
     volumes:
       - ../translator-service:/app
     working_dir: /app


### PR DESCRIPTION
This PR adds an OpenAI API Key as an environment variable for the translator service as an attempt to fix the fetch failed error.